### PR TITLE
Remove disconnected status and deduplicate TTY validation

### DIFF
--- a/ClaudeGlance/Sources/StatusColor.swift
+++ b/ClaudeGlance/Sources/StatusColor.swift
@@ -4,32 +4,12 @@ enum SessionStatus: String, Codable, Hashable {
     case idle
     case busy
     case waiting
-    case disconnected
-
-    var label: String {
-        switch self {
-        case .idle: "idle"
-        case .busy: "working"
-        case .waiting: "input needed"
-        case .disconnected: "disconnected"
-        }
-    }
 
     var color: Color {
         switch self {
         case .idle: Color(red: 0.204, green: 0.780, blue: 0.349)
         case .busy: Color(red: 1.0, green: 0.624, blue: 0.039)
         case .waiting: Color(red: 1.0, green: 0.271, blue: 0.227)
-        case .disconnected: Color(red: 0.557, green: 0.557, blue: 0.576)
-        }
-    }
-
-    var priority: Int {
-        switch self {
-        case .waiting: 3
-        case .busy: 2
-        case .idle: 1
-        case .disconnected: 0
         }
     }
 }

--- a/ClaudeGlance/Sources/String+TTY.swift
+++ b/ClaudeGlance/Sources/String+TTY.swift
@@ -1,0 +1,5 @@
+extension String {
+    var isValidTTY: Bool {
+        !isEmpty && self != "??" && allSatisfy { $0.isLetter || $0.isNumber }
+    }
+}

--- a/ClaudeGlance/Sources/iTerm.swift
+++ b/ClaudeGlance/Sources/iTerm.swift
@@ -4,8 +4,7 @@ enum ITerm {
     private static let bundleID = "com.googlecode.iterm2"
 
     static func focusSession(tty: String) {
-        guard !tty.isEmpty, tty != "??",
-              tty.allSatisfy({ $0.isLetter || $0.isNumber }) else { return }
+        guard tty.isValidTTY else { return }
         guard NSRunningApplication.runningApplications(
             withBundleIdentifier: bundleID
         ).first != nil else { return }


### PR DESCRIPTION
## Why

`SessionStatus.disconnected` is never reported by Claude's statusline — the real states are `idle`, `busy`, and `waiting`. Sessions with unknown status strings were incorrectly shown as grey dots. Additionally, the TTY validation logic was duplicated across two files.

## What

Remove the dead `.disconnected` case entirely and skip sessions with unrecognized status strings. Extract the shared TTY validation into a `String` extension.

## Changes

- **StatusColor.swift**: Remove `.disconnected` case, unused `label` property, and unused `priority` property
- **SessionStore.swift**: Skip unknown status strings instead of falling back to `.disconnected`; use shared `isValidTTY` extension
- **ITerm.swift**: Use shared `isValidTTY` extension
- **String+TTY.swift** (new): Shared `isValidTTY` extension consolidating the duplicated check