### PR TITLE
Fix installed app crash due to missing resource bundle

### DIFF
--- a/ClaudeGlance/Sources/App.swift
+++ b/ClaudeGlance/Sources/App.swift
@@ -121,7 +121,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func makeStatusIcon(color: NSColor) -> NSImage {
         if let cached = iconCache[color] { return cached }
-        guard let logoURL = Bundle.module.url(forResource: "logo-orange", withExtension: "png"),
+        guard let logoURL = Bundle.main.url(forResource: "logo-orange", withExtension: "png"),
               let baseImage = NSImage(contentsOf: logoURL) else { return NSImage() }
 
         let size = NSSize(width: 18, height: 18)

--- a/ClaudeGlance/Sources/LogoView.swift
+++ b/ClaudeGlance/Sources/LogoView.swift
@@ -15,7 +15,7 @@ struct LogoView: View {
     }
 
     private static func loadImage(named name: String) -> NSImage? {
-        guard let url = Bundle.module.url(forResource: name, withExtension: "png") else {
+        guard let url = Bundle.main.url(forResource: name, withExtension: "png") else {
             return nil
         }
         return NSImage(contentsOf: url)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ bundle: build
 	cp ClaudeGlance/Resources/Info.plist $(APP_BUNDLE)/Contents/
 	cp $(BINARY) $(APP_BUNDLE)/Contents/MacOS/
 	cp ClaudeGlance/Resources/AppIcon.icns $(APP_BUNDLE)/Contents/Resources/
+	cp ClaudeGlance/Sources/Resources/*.png $(APP_BUNDLE)/Contents/Resources/
 	codesign --force --sign - $(APP_BUNDLE)
 
 run: bundle


### PR DESCRIPTION
## Why

The installed app (via `install.sh` or `make install`) silently crashes on launch, while `make run` works fine. This happens because SPM compiles resources (logo PNGs) into a separate `ClaudeGlance_ClaudeGlance.bundle`, and the Makefile never copies these resources into the `.app` bundle. The app's `Bundle.module` accessor falls back to a hardcoded absolute build path that only exists on the original build machine.

## What

Copy the PNG resources directly into `Contents/Resources/` (the standard macOS app bundle location) and use `Bundle.main` instead of SPM's `Bundle.module` to load them. This avoids the codesign issue that would occur from placing a nested bundle at the `.app/` root (macOS requires all content under `Contents/`).

## Changes

- **Makefile**: Copy `*.png` from `Sources/Resources/` into `Contents/Resources/` during the `bundle` target
- **App.swift**: Use `Bundle.main` instead of `Bundle.module` for resource loading
- **LogoView.swift**: Use `Bundle.main` instead of `Bundle.module` for resource loading