### PR TITLE
Fix status transition race conditions in hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Add the following to your `~/.claude/settings.json`:
     "PreToolUse": [
       { "hooks": [{ "type": "command", "command": "bash $HOME/.claude-glance/hooks/hook.sh" }] }
     ],
+    "PostToolUse": [
+      { "hooks": [{ "type": "command", "command": "bash $HOME/.claude-glance/hooks/hook.sh" }] }
+    ],
     "Stop": [
       { "hooks": [{ "type": "command", "command": "bash $HOME/.claude-glance/hooks/hook.sh" }] }
     ],
@@ -65,7 +68,8 @@ If you already have hooks configured, merge these entries into your existing `ho
 | `SessionStart` | **idle** -- a new session has started |
 | `UserPromptSubmit` | **busy** -- Claude is processing a prompt |
 | `PreToolUse` | **busy** -- Claude is about to use a tool |
-| `Stop` | **idle** -- Claude has finished responding |
+| `PostToolUse` | **busy** -- a tool has finished running |
+| `Stop` | **idle** -- Claude has finished responding (unless waiting) |
 | `Notification` | **waiting** -- Claude needs your attention |
 
 ## Statusline Setup


### PR DESCRIPTION
## Why

When responding to a notification, the status stays stuck on "waiting" (red) instead of switching to "busy" (orange). This is caused by race conditions between concurrent hook events -- `Notification` can overwrite `UserPromptSubmit`'s "busy" status, and `Stop` can reset a "waiting" status back to "idle".

## What

Serialize concurrent hook writes with a `mkdir`-based file lock and add transition guards so stale events cannot overwrite meaningful statuses. Also add `PostToolUse` support to cover the gap after tool permission approval.

## Changes

- Add `mkdir`-based file locking per session to serialize concurrent hook writes (stale lock auto-cleanup after 2s)
- `Stop` no longer overrides "waiting" -- Claude stopped but still needs attention
- `Notification` no longer overrides "busy" set by `UserPromptSubmit` -- prevents stale notifications from resetting prompt status
- Add `PostToolUse` handler (sets "busy") to cover tool permission approval gap
- Use PID-scoped tmp files (`${SESSION_ID}.${$}.tmp`) to prevent write collisions
- Track `event` field in session JSON for transition guard logic
- Update README with `PostToolUse` hook configuration and updated events table