### PR TITLE
Fix drag triggering expand/collapse toggle

### DIFF
--- a/ClaudeGlance/Sources/FloatingPanel.swift
+++ b/ClaudeGlance/Sources/FloatingPanel.swift
@@ -1,7 +1,12 @@
 import AppKit
 
+extension Notification.Name {
+    static let pillHeaderTapped = Notification.Name("pillHeaderTapped")
+}
+
 final class FloatingPanel: NSPanel {
     private let positionKey = "floatingPanelPosition"
+    private var mouseDownScreenLocation: NSPoint = .zero
     private let containerView = NSView()
     private let visualEffectView = NSVisualEffectView()
 
@@ -64,9 +69,23 @@ final class FloatingPanel: NSPanel {
         restorePosition()
     }
 
+    override func mouseDown(with event: NSEvent) {
+        mouseDownScreenLocation = NSEvent.mouseLocation
+        super.mouseDown(with: event)
+    }
+
     override func mouseUp(with event: NSEvent) {
         super.mouseUp(with: event)
         savePosition()
+
+        let upLocation = NSEvent.mouseLocation
+        let distance = hypot(upLocation.x - mouseDownScreenLocation.x,
+                             upLocation.y - mouseDownScreenLocation.y)
+        let isInHeader = event.locationInWindow.y >= frame.height - PanelLayout.headerHeight
+
+        if distance < 3 && isInHeader {
+            NotificationCenter.default.post(name: .pillHeaderTapped, object: nil)
+        }
     }
 
     func savePosition() {

--- a/ClaudeGlance/Sources/PillView.swift
+++ b/ClaudeGlance/Sources/PillView.swift
@@ -11,16 +11,6 @@ struct PillView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .frame(height: 36)
                 .contentShape(Rectangle())
-                .onTapGesture {
-                    withAnimation(.spring(duration: 0.2)) {
-                        switch widgetState {
-                        case .empty, .collapsed:
-                            widgetState = .expanded
-                        case .expanded:
-                            widgetState = store.sessions.isEmpty ? .empty : .collapsed
-                        }
-                    }
-                }
 
             if widgetState == .expanded {
                 if store.sessions.isEmpty {
@@ -29,6 +19,16 @@ struct PillView: View {
                 } else {
                     SessionDetailView(store: store)
                         .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .pillHeaderTapped)) { _ in
+            withAnimation(.spring(duration: 0.2)) {
+                switch widgetState {
+                case .empty, .collapsed:
+                    widgetState = .expanded
+                case .expanded:
+                    widgetState = store.sessions.isEmpty ? .empty : .collapsed
                 }
             }
         }


### PR DESCRIPTION
## Why

When dragging the pill widget to reposition it, the expand/collapse toggle fires on mouse release. This happens because `isMovableByWindowBackground = true` moves the window with the mouse, so SwiftUI's `onTapGesture` sees no relative movement and always interprets a drag as a tap.

## What

Move click detection from SwiftUI (`onTapGesture`) to the NSPanel level where screen coordinates reveal actual mouse movement. A click is only recognized when the mouse moves less than 3px in screen space and the click lands in the header area.

## Changes

- **FloatingPanel.swift**: Add `mouseDown` override to record screen position, modify `mouseUp` to compare screen-space distance and post a `pillHeaderTapped` notification only for genuine clicks in the header
- **PillView.swift**: Replace `.onTapGesture` with `.onReceive` for the `pillHeaderTapped` notification; keep `.contentShape(Rectangle())` for context menu hit testing