### PR TITLE
Add colorblind-friendly shape toggle for status indicators

### DIFF
--- a/ClaudeGlance/Sources/App.swift
+++ b/ClaudeGlance/Sources/App.swift
@@ -88,6 +88,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         launchItem.state = SMAppService.mainApp.status == .enabled ? .on : .off
         menu.addItem(launchItem)
 
+        let shapesItem = NSMenuItem(
+            title: "Use Shapes for Status",
+            action: #selector(toggleShapesForStatus),
+            keyEquivalent: ""
+        )
+        shapesItem.target = self
+        shapesItem.state = UserDefaults.standard.bool(forKey: "useShapesForStatus") ? .on : .off
+        menu.addItem(shapesItem)
+
         menu.addItem(.separator())
 
         let quitItem = NSMenuItem(
@@ -100,6 +109,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem.menu = menu
         statusItem.button?.performClick(nil)
         statusItem.menu = nil
+    }
+
+    @objc private func toggleShapesForStatus() {
+        let key = "useShapesForStatus"
+        let current = UserDefaults.standard.bool(forKey: key)
+        UserDefaults.standard.set(!current, forKey: key)
     }
 
     @objc private func toggleLaunchAtLogin() {

--- a/ClaudeGlance/Sources/App.swift
+++ b/ClaudeGlance/Sources/App.swift
@@ -94,7 +94,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             keyEquivalent: ""
         )
         shapesItem.target = self
-        shapesItem.state = UserDefaults.standard.bool(forKey: "useShapesForStatus") ? .on : .off
+        shapesItem.state = UserDefaults.standard.bool(forKey: StorageKeys.useShapesForStatus) ? .on : .off
         menu.addItem(shapesItem)
 
         menu.addItem(.separator())
@@ -112,9 +112,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func toggleShapesForStatus() {
-        let key = "useShapesForStatus"
-        let current = UserDefaults.standard.bool(forKey: key)
-        UserDefaults.standard.set(!current, forKey: key)
+        let current = UserDefaults.standard.bool(forKey: StorageKeys.useShapesForStatus)
+        UserDefaults.standard.set(!current, forKey: StorageKeys.useShapesForStatus)
     }
 
     @objc private func toggleLaunchAtLogin() {

--- a/ClaudeGlance/Sources/PillView.swift
+++ b/ClaudeGlance/Sources/PillView.swift
@@ -4,6 +4,7 @@ struct PillView: View {
     let store: SessionStore
     @Binding var widgetState: WidgetState
     var onHidePanel: (() -> Void)?
+    @AppStorage(StorageKeys.useShapesForStatus) private var useShapes = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -77,7 +78,7 @@ struct PillView: View {
 
                 ForEach(store.countsByStatus) { item in
                     HStack(spacing: 3) {
-                        StatusShapeView(status: item.status, size: 8)
+                        StatusShapeView(status: item.status, size: 8, useShapes: useShapes)
                         Text("\(item.count)")
                             .font(.system(size: 12, weight: .medium, design: .monospaced))
                             .foregroundStyle(.primary)

--- a/ClaudeGlance/Sources/PillView.swift
+++ b/ClaudeGlance/Sources/PillView.swift
@@ -77,9 +77,7 @@ struct PillView: View {
 
                 ForEach(store.countsByStatus) { item in
                     HStack(spacing: 3) {
-                        Circle()
-                            .fill(item.status.color)
-                            .frame(width: 8, height: 8)
+                        StatusShapeView(status: item.status, size: 8)
                         Text("\(item.count)")
                             .font(.system(size: 12, weight: .medium, design: .monospaced))
                             .foregroundStyle(.primary)

--- a/ClaudeGlance/Sources/SessionDetailView.swift
+++ b/ClaudeGlance/Sources/SessionDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SessionDetailView: View {
     let store: SessionStore
+    @AppStorage(StorageKeys.useShapesForStatus) private var useShapes = false
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Divider()
@@ -15,7 +16,7 @@ struct SessionDetailView: View {
                             ITerm.focusSession(tty: session.tty)
                         } label: {
                             HStack(spacing: 8) {
-                                StatusShapeView(status: session.status, size: 6)
+                                StatusShapeView(status: session.status, size: 6, useShapes: useShapes)
 
                                 Text(session.projectName)
                                     .font(.system(size: 11, weight: .medium))

--- a/ClaudeGlance/Sources/SessionDetailView.swift
+++ b/ClaudeGlance/Sources/SessionDetailView.swift
@@ -15,9 +15,7 @@ struct SessionDetailView: View {
                             ITerm.focusSession(tty: session.tty)
                         } label: {
                             HStack(spacing: 8) {
-                                Circle()
-                                    .fill(session.status.color)
-                                    .frame(width: 6, height: 6)
+                                StatusShapeView(status: session.status, size: 6)
 
                                 Text(session.projectName)
                                     .font(.system(size: 11, weight: .medium))

--- a/ClaudeGlance/Sources/StatusShapeView.swift
+++ b/ClaudeGlance/Sources/StatusShapeView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct TriangleShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        Path { path in
+            path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+            path.closeSubpath()
+        }
+    }
+}
+
+struct StatusShapeView: View {
+    let status: SessionStatus
+    let size: CGFloat
+
+    @AppStorage("useShapesForStatus") private var useShapes = false
+
+    var body: some View {
+        if useShapes {
+            shapedIndicator
+        } else {
+            Circle()
+                .fill(status.color)
+                .frame(width: size, height: size)
+        }
+    }
+
+    @ViewBuilder
+    private var shapedIndicator: some View {
+        switch status {
+        case .idle:
+            Circle()
+                .fill(status.color)
+                .frame(width: size, height: size)
+        case .busy:
+            TriangleShape()
+                .fill(status.color)
+                .frame(width: size, height: size)
+        case .waiting:
+            RoundedRectangle(cornerRadius: size * 0.15)
+                .fill(status.color)
+                .frame(width: size, height: size)
+        }
+    }
+}

--- a/ClaudeGlance/Sources/StatusShapeView.swift
+++ b/ClaudeGlance/Sources/StatusShapeView.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+enum StorageKeys {
+    static let useShapesForStatus = "useShapesForStatus"
+}
+
 struct TriangleShape: Shape {
     func path(in rect: CGRect) -> Path {
         Path { path in
@@ -14,9 +18,9 @@ struct TriangleShape: Shape {
 struct StatusShapeView: View {
     let status: SessionStatus
     let size: CGFloat
+    let useShapes: Bool
 
-    @AppStorage("useShapesForStatus") private var useShapes = false
-
+    @ViewBuilder
     var body: some View {
         if useShapes {
             shapedIndicator
@@ -29,6 +33,7 @@ struct StatusShapeView: View {
 
     @ViewBuilder
     private var shapedIndicator: some View {
+        let triangleSize = size * 1.15
         switch status {
         case .idle:
             Circle()
@@ -37,7 +42,7 @@ struct StatusShapeView: View {
         case .busy:
             TriangleShape()
                 .fill(status.color)
-                .frame(width: size, height: size)
+                .frame(width: triangleSize, height: triangleSize)
         case .waiting:
             RoundedRectangle(cornerRadius: size * 0.15)
                 .fill(status.color)


### PR DESCRIPTION
## Why

Status indicators rely solely on color (green/orange/red circles) to convey session state. Colorblind users cannot distinguish between these, making the app less accessible.

## What

Add a user-togglable "Use Shapes for Status" option that double-encodes status using both color and shape: circle for idle, triangle for busy, square for waiting. Default behavior (colored circles) is unchanged.

## Changes

- Create `StatusShapeView.swift` with a reusable `StatusShapeView` that reads `@AppStorage("useShapesForStatus")` and renders the appropriate shape per status, plus a custom `TriangleShape` (SwiftUI has no built-in triangle)
- Replace `Circle()` in `PillView.swift` and `SessionDetailView.swift` with `StatusShapeView`
- Add "Use Shapes for Status" checkmark menu item and toggle handler in `App.swift`