### PR TITLE
Fix iTerm2 focus on session click — add missing NSAppleEventsUsageDescription

### DIFF
--- a/ClaudeGlance/Resources/Info.plist
+++ b/ClaudeGlance/Resources/Info.plist
@@ -24,5 +24,7 @@
     <true/>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Claude Glance needs to control iTerm2 to focus the terminal tab running your Claude Code session.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

Clicking on a repo name in Claude Glance is supposed to focus the iTerm2 tab running that Claude Code session via AppleScript (`iTerm.swift`). This feature **silently fails on all sessions**.

The root cause is a missing `NSAppleEventsUsageDescription` key in `Info.plist`. Without this key:
- macOS **silently blocks** all `NSAppleScript` calls to external applications
- The Automation permission prompt is **never triggered**
- The app **never appears** in System Settings > Privacy & Security > Automation
- There is **no way to grant the permission manually** — a rebuild is required

The error goes unnoticed because `iTerm.swift` executes the script asynchronously and doesn't log the `NSAppleScript` error.

## Fix

Add the `NSAppleEventsUsageDescription` usage description string to `Info.plist`:

```xml
<key>NSAppleEventsUsageDescription</key>
<string>Claude Glance needs to control iTerm2 to focus the terminal tab running your Claude Code session.</string>
```

After rebuilding, macOS will prompt the user to allow Claude Glance to control iTerm2 on first click, and the feature works as expected.

## Test plan

- [ ] Rebuild and launch ClaudeGlance
- [ ] Click on a session with a valid TTY
- [ ] macOS should prompt "Claude Glance wants to control iTerm2" on first click
- [ ] After accepting, iTerm2 focuses the correct tab


🤖 Generated with [Claude Code](https://claude.com/claude-code)